### PR TITLE
Add links to docs in the description, set min RC version, and fix author institutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides alternative display modes for field notes. This module adds an action t
 - [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules)
 
 ## Installation
-- Clone this repo into to `<redcap-root>/modules/field_notes_display_v1.1`.
+- Clone this repo into to `<redcap-root>/modules/field_notes_display_v<version_number>`.
 - Go to **Control Center > Manage External Modules** and enable Field Notes Display.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Field Notes Display for that project.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides alternative display modes for field notes. This module adds an action t
 
 
 ## How to use
-Once the module is activated on a project, the @FIELD-NOTES-DISPLAY will be available in the action tag help text of the Online Designer. Add @FIELD-NOTES-DISPLAY to any field where you would like to display the field note using one of the three display.  Specify the display mode you would like to use as a paremeter to the action tag.  Valid display modes are `hover`, `tooltip`, and `popover`.  Provide the content of the field note as usual.
+Once the module is activated on a project, the @FIELD-NOTES-DISPLAY will be available in the action tag help text of the Online Designer. Add @FIELD-NOTES-DISPLAY to any field where you would like to display the field note using one of the three display modes.  Specify the display mode you would like to use as a parameter to the action tag.  Valid display modes are `hover`, `tooltip`, and `popover`.  Provide the content of the field note as usual.
 
 
 ### Example:

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Field Notes Display",
     "namespace": "FieldNotesDisplay\\ExternalModule",
-    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display/tree/1.0.0' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display/tree/1.0.0' target='_blank'>https://github.com/ctsit/field_notes_display/tree/1.0.0</a>.",
+    "description": "Provides alternative display modes for field notes.  This module adds an action tag @FIELD-NOTES-DISPLAY that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display' target='_blank'>https://github.com/ctsit/field_notes_display</a>.",
     "permissions": [
         "hook_every_page_top"
     ],

--- a/config.json
+++ b/config.json
@@ -9,37 +9,37 @@
         {
             "name": "Philip Chase",
             "email": "pbc@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Taryn Stoffs",
             "email": "tls@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Surya Prasanna",
             "email": "suryayalla@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Prasad Lanka",
             "email": "planka@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Dileep Rajput",
             "email": "rajputd@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Tiago Bember",
             "email": "tbembersimeao@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Mike Conlon, Ph.D.",
             "email": "mconlon@ufl.edu",
-            "institution": "University of Florida"
+            "institution": "University of Florida - CTSI"
         }
     ]
 }

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Field Notes Display",
     "namespace": "FieldNotesDisplay\\ExternalModule",
-    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display'>https://github.com/ctsit/field_notes_display</a>.",
+    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display' target='_blank'>https://github.com/ctsit/field_notes_display</a>.",
     "permissions": [
         "hook_every_page_top"
     ],

--- a/config.json
+++ b/config.json
@@ -41,5 +41,9 @@
             "email": "mconlon@ufl.edu",
             "institution": "University of Florida - CTSI"
         }
-    ]
+    ],
+    "compatibility": {
+        "redcap-version-min": "8.0.3",
+        "redcap-version-max": ""
+   }
 }

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Field Notes Display",
     "namespace": "FieldNotesDisplay\\ExternalModule",
-    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.",
+    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display'>https://github.com/ctsit/field_notes_display</a>.",
     "permissions": [
         "hook_every_page_top"
     ],

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "name": "Field Notes Display",
     "namespace": "FieldNotesDisplay\\ExternalModule",
-    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display' target='_blank'>https://github.com/ctsit/field_notes_display</a>.",
+    "description": "Provides alternative display modes for field notes.  This module adds an action tag @field-notes-display that accepts the following inputs: 'hover' - displays the text when the field is hovered over; 'tooltip' - places a help icon, which displays the text in a tooltip when hovered over; 'popover' - places a help icon, which displays the text in a popover when clicked.  See the complete <b><a href='https://github.com/ctsit/field_notes_display/tree/1.0.0' target='_blank'>documentation</a></b> at <a href='https://github.com/ctsit/field_notes_display/tree/1.0.0' target='_blank'>https://github.com/ctsit/field_notes_display/tree/1.0.0</a>.",
     "permissions": [
         "hook_every_page_top"
     ],


### PR DESCRIPTION
Add links to the Github docs in the description, set the minimum REDCap version, and make author institutions conform the name in the REDCap Community.